### PR TITLE
Adding capability to target ReadTheDocs for Business

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+OS=$(shell go env GOOS)
+ARCH=$(shell go env GOARCH)
+
 terraform-provider-readthedocs: *.go */*.go go.mod docs/index.md test
 	go build .
 
@@ -11,8 +14,8 @@ testacc: test
 	TF_ACC=1 go test ./...
 
 install: terraform-provider-readthedocs
-	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/BarnabyShearer/readthedocs/0.1.0/linux_amd64
-	cp $+ ~/.terraform.d/plugins/registry.terraform.io/BarnabyShearer/readthedocs/0.1.0/linux_amd64
+	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/BarnabyShearer/readthedocs/0.1.0/$(OS)_$(ARCH)
+	cp $+ ~/.terraform.d/plugins/registry.terraform.io/BarnabyShearer/readthedocs/0.1.0/$(OS)_$(ARCH)
 	-rm .terraform.lock.hcl
 	terraform init
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BarnabyShearer/terraform-provider-readthedocs
 go 1.16
 
 require (
-	github.com/BarnabyShearer/readthedocs/v3 v3.0.9
+	github.com/BarnabyShearer/readthedocs/v3 v3.0.10
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/BarnabyShearer/readthedocs/v3 v3.0.9 h1:PBHvkOijWgfManyjvn5UzqWGQBCePVA5W1szMxl1/c0=
-github.com/BarnabyShearer/readthedocs/v3 v3.0.9/go.mod h1:9Cbd6gcXkhM3MEOXzyquCs3nUurFSHuq9hFbcQfG+44=
+github.com/BarnabyShearer/readthedocs/v3 v3.0.10 h1:37DvonTR7qBIXYbEZvF9rT+WGg5dWHah+Q8XndE8FoA=
+github.com/BarnabyShearer/readthedocs/v3 v3.0.10/go.mod h1:9Cbd6gcXkhM3MEOXzyquCs3nUurFSHuq9hFbcQfG+44=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/readthedocs/provider.go
+++ b/readthedocs/provider.go
@@ -33,5 +33,5 @@ func Provider() *schema.Provider {
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	return rtd.NewClient(d.Get("token").(string), d.Get("base_url").(string)), nil
+	return rtd.NewClientWithURL(d.Get("token").(string), d.Get("base_url").(string)), nil
 }

--- a/readthedocs/provider.go
+++ b/readthedocs/provider.go
@@ -18,6 +18,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("READTHEDOCS_TOKEN", nil),
 				Description: "API Token for authentication.",
 			},
+			"base_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("READTHEDOCS_BASE_URL", "https://readthedocs.org/api/v3"),
+				Description: "ReadTheDocs API base URL. Can be used to target the Read The Docs For Business API.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"readthedocs_project": resourceProject(),
@@ -27,5 +33,5 @@ func Provider() *schema.Provider {
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	return rtd.NewClient(d.Get("token").(string)), nil
+	return rtd.NewClient(d.Get("token").(string), d.Get("base_url").(string)), nil
 }

--- a/readthedocs/resource_project.go
+++ b/readthedocs/resource_project.go
@@ -89,6 +89,18 @@ func resourceProject() *schema.Resource {
 				Optional:    true,
 				Description: "Build PRs.",
 			},
+			"organization": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "ReadTheDocs for Business organization where the project should be created. Only valid when using Read The Docs for Business.",
+			},
+			"teams": {
+				Type:        schema.TypeString,
+				Default:     "",
+				Optional:    true,
+				Description: "Team slugs the project will belong to. Only valid when using Read The Docs for Business.",
+			},
 		},
 	}
 }
@@ -104,6 +116,8 @@ func updateReqest(d *schema.ResourceData) rtd.CreateUpdateProject {
 			Homepage:            "",
 			ProgrammingLanguage: d.Get("programming_language").(string),
 			Language:            d.Get("language").(string),
+			Organization:        d.Get("organization").(string),
+			Teams:               d.Get("teams").(string),
 		},
 		DefaultVersion:        d.Get("default_version").(string),
 		DefaultBranch:         d.Get("default_branch").(string),


### PR DESCRIPTION
ReadTheDocs has two main endpoints:
https://readthedocs.org/ and
https://readthedocs.com/
as per [their docs](https://docs.readthedocs.io/en/stable/commercial/index.html#read-the-docs-for-business)

Added a new provider configuration field named `base_url` that allows us to target the business API.
Added `organization` and `teams` fields since they are required when using the business API.
Currently there is no validation wether you are setting the `organization` or `teams` fields when using the community API. 
Thats something that perhaps makes sense but I am not exactly sure what is the best way to implement it.
